### PR TITLE
secure DOIs

### DIFF
--- a/_layouts/mybiblio.html
+++ b/_layouts/mybiblio.html
@@ -5,7 +5,7 @@
     <ul class="nav nav-pills">
         {% if entry.doi %} 
         <li> 
-            <a class="bib-materials" href="http://dx.doi.org/{{entry.doi}}">
+            <a class="bib-materials" href="https://doi.org/{{entry.doi}}">
                 DOI
             </a>
         </li>


### PR DESCRIPTION
Hello @adliska :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update the code that generates new DOI links.

Cheers!